### PR TITLE
Should fix the "cd ." gem building issue on FreeBSD: uses an extconf-make.rb file to accomplish this.

### DIFF
--- a/ext/extconf-make.rb
+++ b/ext/extconf-make.rb
@@ -1,0 +1,25 @@
+require 'rbconfig'
+
+$CXXFLAGS = ENV['CXXFLAGS']
+$PATH = ENV['SOURCE_DIR']
+$GMAKE_CMD = ENV['GMAKE_CMD']
+
+HERE = ENV['HERE']
+
+BSD = RbConfig::CONFIG['build_os'] =~ /^freebsd|^openbsd/
+
+Dir.chdir(HERE)
+
+old_dir = Dir.pwd
+
+Dir.chdir($PATH)
+
+system("cd .") if BSD #Fix for a "quirk" that BSD has..
+        
+puts(cmd = "#{$GMAKE_CMD} CXXFLAGS='#{$CXXFLAGS}' || true 2>&1")
+raise "'#{cmd}' failed" unless system(cmd)
+
+puts(cmd = "#{$GMAKE_CMD} install || true 2>&1")
+raise "'#{cmd}' failed" unless system(cmd)
+
+Dir.chdir(old_dir)

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -72,11 +72,8 @@ def check_libmemcached
         puts(cmd = "env CFLAGS='-fPIC #{$CFLAGS}' LDFLAGS='-fPIC #{$LDFLAGS}' ./configure --prefix=#{HERE} --without-memcached --disable-shared --disable-utils --disable-dependency-tracking #{$EXTRA_CONF} 2>&1")
         raise "'#{cmd}' failed" unless system(cmd)
 
-        puts(cmd = "#{GMAKE_CMD} CXXFLAGS='#{$CXXFLAGS}' || true 2>&1")
-        raise "'#{cmd}' failed" unless system(cmd)
-
-        puts(cmd = "#{GMAKE_CMD} install || true 2>&1")
-        raise "'#{cmd}' failed" unless system(cmd)
+        #Running the make command in another script invoked by another shell command solves the "cd ." issue on FreeBSD 6+
+        system("GMAKE_CMD='#{GMAKE_CMD}' CXXFLAGS='#{$CXXFLAGS}' SOURCE_DIR='#{BUNDLE_PATH}' HERE='#{HERE}' ruby ../extconf-make.rb")
       end
 
       system("rm -rf #{BUNDLE_PATH}") unless ENV['DEBUG'] or ENV['DEV']


### PR DESCRIPTION
I put my changes onto the recent master. A few things:

1) The extconf-make.rb file is what effectively fixes the bug on BSD; occasionally, after running a make script, the shell (accessible to the script) is not updated with the new directory structure. Running a separate ruby script with a new shell command refreshes the directory structure and will let the make install proceed.

2) There is a branch I have called "local_fixes": I had to modify the Includes & Libraries variables to include "/usr/local/lib". Some distributions of BSD (particularly in managed hosting) don't come with package managers, and there seems to be some issues with automatic linking or trying to detect installed /compiled libraries if that is the case. I'm not 100% sure this should go into master - there should be a cleaner way of doing this than simply spamming the path - but I thought I would mention it, and point out where it was, because that was my final step to getting the gem working on FreeBSD 6.2. 

Hope this helps.
