### PR TITLE
Naive fix to binary_incr_decr

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -67,6 +67,7 @@ def check_libmemcached
       patch("libmemcached-7", "pipelined delete and unused replica code")
       patch("libmemcached-8", "avoid strdup() to work around tcmalloc on OS X bug")
       patch("libmemcached-9", "don't clone server_st by reference server_by_key()")
+      patch("libmemcached-10", "binary_incr_decr() respects prefix_key")
 
       run("touch -r #{BUNDLE_PATH}/m4/visibility.m4 #{BUNDLE_PATH}/configure.ac #{BUNDLE_PATH}/m4/pandora_have_sasl.m4", "Touching aclocal.m4 in libmemcached.")
 

--- a/ext/libmemcached-10.patch
+++ b/ext/libmemcached-10.patch
@@ -1,0 +1,33 @@
+diff --git a/libmemcached-0.32/libmemcached/memcached_auto.c b/libmemcached-0.32/libmemcached/memcached_auto.c
+--- a/libmemcached-0.32/libmemcached/memcached_auto.c
++++ b/libmemcached-0.32/libmemcached/memcached_auto.c
+@@ -82,20 +82,26 @@ static memcached_return binary_incr_decr(memcached_st *ptr, uint8_t cmd,
+       cmd= PROTOCOL_BINARY_CMD_INCREMENTQ;
+   }
+   protocol_binary_request_incr request= {.bytes= {0}};
++  
++  uint16_t key_with_prefix_length = strlen(ptr->prefix_key) + strlen(key);
++  char *key_with_prefix = alloca(key_with_prefix_length + 1);
++  strcpy(key_with_prefix, ptr->prefix_key);
++  strcat(key_with_prefix, key);
++  
+ 
+   request.message.header.request.magic= PROTOCOL_BINARY_REQ;
+   request.message.header.request.opcode= cmd;
+-  request.message.header.request.keylen= htons((uint16_t) key_length);
++  request.message.header.request.keylen= htons((uint16_t) key_with_prefix_length);
+   request.message.header.request.extlen= 20;
+   request.message.header.request.datatype= PROTOCOL_BINARY_RAW_BYTES;
+-  request.message.header.request.bodylen= htonl((uint32_t) (key_length + request.message.header.request.extlen));
++  request.message.header.request.bodylen= htonl((uint32_t) (key_with_prefix_length + request.message.header.request.extlen));
+   request.message.body.delta= htonll(offset);
+   request.message.body.initial= htonll(initial);
+   request.message.body.expiration= htonl((uint32_t) expiration);
+ 
+   if ((memcached_do(&ptr->hosts[server_key], request.bytes,
+                     sizeof(request.bytes), 0)!=MEMCACHED_SUCCESS) ||
+-      (memcached_io_write(&ptr->hosts[server_key], key, key_length, 1) == -1)) 
++      (memcached_io_write(&ptr->hosts[server_key], key_with_prefix, key_with_prefix_length, 1) == -1)) 
+   {
+     memcached_io_reset(&ptr->hosts[server_key]);
+     return MEMCACHED_WRITE_FAILURE;


### PR DESCRIPTION
It's my first code in c in ages and it's pretty naive. I hope it not a bother to recheck it, and propably dump it :) I think it's missing check if there is a need to use prefix key (strlen(ptr->prefix_key) != 0 {do }), but i don't know how to write it efficiently. Thank you for wonderful lib :)
