### PR TITLE
removing the extra whitespace in cas requests

### DIFF
--- a/ext/libmemcached-0.32/libmemcached/memcached_storage.c
+++ b/ext/libmemcached-0.32/libmemcached/memcached_storage.c
@@ -95,7 +95,7 @@ static inline memcached_return memcached_send(memcached_st *ptr,
 
   if (cas)
     write_length= (size_t) snprintf(buffer, MEMCACHED_DEFAULT_COMMAND_SIZE,
-                                    "%s %s%.*s %u %llu %zu %llu%s\r\n",
+                                    "%s%s%.*s %u %llu %zu %llu%s\r\n",
                                     storage_op_string(verb),
                                     ptr->prefix_key,
                                     (int)key_length, key, flags,


### PR DESCRIPTION
cas has an extra whitespace between verb and key, removing one from the format string
