### PR TITLE
Add Memcached::SomeErrorsWereReported to exceptions_to_retry

### DIFF
--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -47,7 +47,8 @@ class Memcached
         Memcached::ServerError,
         Memcached::SystemError,
         Memcached::UnknownReadFailure,
-        Memcached::WriteFailure]
+        Memcached::WriteFailure,
+        Memcached::SomeErrorsWereReported]
   }
 
 #:stopdoc:


### PR DESCRIPTION
libmemcached library returns MEMCACHED_SOME_ERRORS when memcached_io_write fails. The correct error should be MEMCACHED_ERRNO, but libmemcached library does not bother to set the cached_errno. Since the write failure might represent a transient error, we should retry requests that failed with MEMCACHED_SOME_ERRORS
