### PR TITLE
Remove pedantic CFLAG that prevents compilation from extconf if present

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -7,7 +7,7 @@ BUNDLE_PATH = Dir.glob("libmemcached-*").first
 SOLARIS_32 = Config::CONFIG['target'] == "i386-pc-solaris2.10"
 BSD = Config::CONFIG['host_os'].downcase =~ /bsd/
 
-$CFLAGS = "#{Config::CONFIG['CFLAGS']} #{$CFLAGS}".gsub("$(cflags)", "").gsub("-fno-common", "")
+$CFLAGS = "#{Config::CONFIG['CFLAGS']} #{$CFLAGS}".gsub("$(cflags)", "").gsub("-fno-common", "").gsub("-Werror=declaration-after-statement", "")
 $CFLAGS << " -std=gnu99" if SOLARIS_32
 $CFLAGS << " -I/usr/local/include" if BSD
 $EXTRA_CONF = " --disable-64bit" if SOLARIS_32


### PR DESCRIPTION
Remove -Werror=declaration-after-statement from CFLAGS if present since it will prevent the native extension from compiling.

(Arch Linux with gcc 4.6.1, rvm 1.6.20 and ruby 1.9.3-HEAD)
