### PR TITLE
Use portable sed invocation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ ext/lib
 ext/share
 ext/**/Makefile
 ext/libmemcached-*/**/Makefile
+ext/libmemcached-*/autom4te.cache
 ext/libmemcached-*/clients/memcat
 ext/libmemcached-*/clients/memcp
 ext/libmemcached-*/clients/memdump
@@ -31,5 +32,6 @@ ext/libmemcached-*/tests/startservers
 ext/libmemcached-*/tests/testapp
 ext/libmemcached-*/tests/testplus
 ext/libmemcached-*/tests/udptest
+ext/rlibmemcached_wrap.c.in
 *.[1,3]
 .libs

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -72,10 +72,15 @@ check_libmemcached
 
 if ENV['SWIG']
   puts "WARNING: Swig 2.0.2 not found. Other versions may not work." if (`swig -version`!~ /2.0.2/)
-  run("swig #{$defines} #{$includes} -ruby -autorename rlibmemcached.i", "Running SWIG.")
-  run("sed -i '' 's/STR2CSTR/StringValuePtr/' rlibmemcached_wrap.c", "Patching SWIG output for Ruby 1.9.")
-  run("sed -i '' 's/\"swig_runtime_data\"/\"SwigRuntimeData\"/' rlibmemcached_wrap.c", "Patching SWIG output for Ruby 1.9.")
-  run("sed -i '' 's/#ifndef RUBY_INIT_STACK/#ifdef __NEVER__/g' rlibmemcached_wrap.c", "Patching SWIG output for JRuby.")
+  run("swig #{$defines} #{$includes} -ruby -autorename -o rlibmemcached_wrap.c.in rlibmemcached.i", "Running SWIG.")
+  swig_patches = {
+    "STR2CSTR" => "StringValuePtr",                                # Patching SWIG output for Ruby 1.9.
+    "\"swig_runtime_data\"" =>  "\"SwigRuntimeData\"",             # Patching SWIG output for Ruby 1.9.
+    "#ifndef RUBY_INIT_STACK" => "#ifdef __NEVER__",               # Patching SWIG output for JRuby.
+  }.map{|pair| "s/#{pair.join('/')}/"}.join(';')
+
+  # sed has different syntax for inplace switch in BSD and GNU version, so using intermediate file
+  run("sed '#{swig_patches}' rlibmemcached_wrap.c.in > rlibmemcached_wrap.c", "Apply patches to SWIG output")
 end
 
 $CFLAGS << " -Os"


### PR DESCRIPTION
Hi, guys

sed utility uses different syntax for in-place switch for BSD(macos) and GNU(linux) versions.

Linux: there no space after -i http://linux.die.net/man/1/sed
Macos: there should be space after -i and they doesn't support long version http://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man1/sed.1.html

So they are mutually exclusive.

This patch provides portable invocation using intermediate file.
