### PR TITLE
Don't process binary files with RDoc. Fixes #51

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ Echoe.new("memcached") do |p|
   p.project = "fauna"
   p.summary = "An interface to the libmemcached C client."
   p.rdoc_pattern = /README|TODO|LICENSE|CHANGELOG|BENCH|COMPAT|exceptions|experimental.rb|behaviors|rails.rb|memcached.rb/
+  p.rdoc_options = %w[--line-numbers --inline-source --title Memcached --main README --exclude=ext/bin --exclude=ext/libmemcached-.*/(clients|tests)]
   p.clean_pattern += ["ext/Makefile",
                       "ext/bin",
                       "ext/include",


### PR DESCRIPTION
Hi guys

This patch excludes binary files from RDoc targets which fixes issue #51

I extracted default options from echoe, because it doesn't merge changes for `rdoc_options` (which is makes sence). And `--title` option became static (gem echoe uses some code to determine rdoc title from gem name https://github.com/fauna/echoe/blob/master/lib/echoe.rb#L201 but it's ok here I think).

Thanks 
