### PR TITLE
memcache protocol returns EXISTS the when item you are trying to store wi

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+v1.3.1 rescue ConnectionDataExists for cas because Rails shim over Memcached is not supposed to raise anything for legacy reasons
+
 v1.3. Improvements to BSD support; add Memcached#touch method (avsej).
 
 v1.2.7.1 Retry SomeErrorsWereReported exception

--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -163,8 +163,6 @@ Please note that when <tt>:no_block => true</tt>, update methods do not raise on
       @not_found.no_backtrace = true
       @not_stored = NotStored.new
       @not_stored.no_backtrace = true
-      @exists = ConnectionDataExists.new
-      @exists.no_backtrace = true
     end
   end
 
@@ -586,8 +584,6 @@ Please note that when <tt>:no_block => true</tt>, update methods do not raise on
       raise @not_found # Lib::MEMCACHED_NOTFOUND
     elsif ret == 14
       raise @not_stored # Lib::MEMCACHED_NOTSTORED
-    elsif ret == 12
-      raise @exists # Lib::MEMCACHED_DATA_EXISTS
     else
       reraise(key, ret)
     end

--- a/test/unit/rails_test.rb
+++ b/test/unit/rails_test.rb
@@ -90,10 +90,11 @@ class RailsTest < Test::Unit::TestCase
     # Conflicting set after a gets
     cache.set key, @value
     assert_nothing_raised do
-      cache.cas(key) do |current|
-          cache.set key, value2
-          current
+      result = cache.cas(key) do |current|
+        cache.set key, value2
+        current
       end
+      assert_equal result, false
     end
     assert_equal value2, cache.get(key)
   end


### PR DESCRIPTION
Memcache protocol returns EXISTS, when item you are trying to store with a cas has been modified since you last fetched it. The Rails shim over Memcached is supposed to not raise anything for legacy reasons. In order to achieve this, we must rescue ConnectionDataExists!
