### PR TITLE
Touch "#{BUNDLE_PATH}/aclocal.m4"

### DIFF
--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -47,7 +47,7 @@ def check_libmemcached
   $DEFLIBPATH = [] unless SOLARIS_32
 
   Dir.chdir(HERE) do
-    run("touch -r #{BUNDLE_PATH}/m4/visibility.m4 #{BUNDLE_PATH}/configure.ac #{BUNDLE_PATH}/m4/pandora_have_sasl.m4 #{BUNDLE_PATH}/m4/aclocal.m4", "Touching aclocal.m4 in libmemcached.")
+    run("touch -r #{BUNDLE_PATH}/m4/visibility.m4 #{BUNDLE_PATH}/configure.ac #{BUNDLE_PATH}/m4/pandora_have_sasl.m4 #{BUNDLE_PATH}/aclocal.m4", "Touching aclocal.m4 in libmemcached.")
 
     Dir.chdir(BUNDLE_PATH) do
       run("env CFLAGS='-fPIC #{LIBM_CFLAGS}' LDFLAGS='-fPIC #{LIBM_LDFLAGS}' ./configure --prefix=#{HERE} --without-memcached --disable-shared --disable-utils --disable-dependency-tracking #{$CC} #{$EXTRA_CONF} 2>&1", "Configuring libmemcached.")


### PR DESCRIPTION
Previously `#{BUNDLE_PATH}/m4/aclocal.m4` was being touched, which is not being used.

This prevents running autoconf and fixes #69.
