### PR TITLE
Cast TTL values to integers to better support ActiveSupport::Duration values.

### DIFF
--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -501,9 +501,11 @@ class MemcachedTest < Test::Unit::TestCase
     assert_raise(Memcached::NotFound) do
       @cache.get key
     end
+  end
 
-    assert_raise(TypeError) do
-      @cache.set key, @value, Time.now
+  def test_set_time_in_past
+    assert_raise(ArgumentError) do
+      @cache.set key, @value, Time.now - 10
     end
   end
 


### PR DESCRIPTION
This pull request addresses issue #39 which is still present despite being closed and agreed to be fixed if a pull was submitted.

Cast TTL values to integers to better support ActiveSupport::Duration values.
To avoid special casing Active::SupportDuration, this patch just calls
to_i on the ttl value, but this causes a problem if the the argument is
a Time object. So this patch also now allows Time values to be passed
as long as they are in the future by converting them to a duration of
time in seconds.
