### PR TITLE
Correct README to identify additional requirement

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,4 +1,3 @@
-
 memcached
 
 An interface to the libmemcached C client.
@@ -18,7 +17,7 @@ The <b>memcached</b> library wraps the pure-C libmemcached client via SWIG.
 
 == Installation
 
-You need Ruby 1.8.7 or Ruby 1.9.2. Other versions may work, but are not guaranteed. You also need the libsasl2-dev library, which should be provided through your system's package manager.
+You need Ruby 1.8.7 or Ruby 1.9.2. Other versions may work, but are not guaranteed. You also need the `libsasl2-dev` and `gettext` libraries, which should be provided through your system's package manager.
 
 Install the gem:
   sudo gem install memcached --no-rdoc --no-ri


### PR DESCRIPTION
Adds `gettext` as an installation requirement
