### PR TITLE
Added Memcached::ServerEnd to the list of exceptions to retry

### DIFF
--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -1,4 +1,3 @@
-
 =begin rdoc
 The Memcached client class.
 =end
@@ -44,6 +43,7 @@ class Memcached
         Memcached::Failure,
         Memcached::MemoryAllocationFailure,
         Memcached::ReadFailure,
+        Memcached::ServerEnd,
         Memcached::ServerError,
         Memcached::SystemError,
         Memcached::UnknownReadFailure,


### PR DESCRIPTION
Some old versions of memcache raise ServerEnd exceptions when a SET follows a GET that raises a Memcached::NotFound error.  Adding this line solves that problem.

For example, see https://github.com/evan/memcached/pull/50

I understand that this should be fixed already in the current release, but in systems where earlier versions of memcached needs to be used for compatibility reasons, this patch is an easy fix to solve the ServerEnd exception problem.
