### PR TITLE
Fixed the servers method in the rails wrapper

### DIFF
--- a/lib/memcached/rails.rb
+++ b/lib/memcached/rails.rb
@@ -151,7 +151,6 @@ class Memcached
           next_retry <= Time.now
         end unless server.respond_to?(:alive?)
       end
-      server_structs
     end
 
     # Wraps Memcached#set_servers to convert server objects to strings.

--- a/test/unit/rails_test.rb
+++ b/test/unit/rails_test.rb
@@ -126,6 +126,12 @@ class RailsTest < Test::Unit::TestCase
     compare_servers @cache, @servers
   end
 
+  def test_servers_alive
+    @cache.servers.each do |server|
+      assert server.alive?
+    end
+  end
+
   def test_set_servers
     cache = Memcached::Rails.new(:servers => @servers, :namespace => @namespace)
     compare_servers cache, @servers


### PR DESCRIPTION
I'm afraid you broke the servers method slightly ;-)

Calling server_structs a second time returns a fresh array which hasn't had the alive? methods added, so we need to return the original, modified, array. I've also add a test to make sure the alive? method is working.
