### PR TITLE
Make sure memcached_fetch arguments have default values

### DIFF
--- a/ext/rlibmemcached_wrap.c
+++ b/ext/rlibmemcached_wrap.c
@@ -9016,12 +9016,11 @@ _wrap_memcached_fetch(int argc, VALUE *argv, VALUE self) {
   char *result = 0 ;
   VALUE vresult = Qnil;
 
-  {
-    char string[256];
-    size_t length = 0;
-    arg2 = string;
-    arg3 = &length;
-  }
+  char string[256];
+  size_t length = 0;
+  arg2 = string;
+  arg3 = &length;
+    
   arg4 = &temp4;
   arg5 = &temp5;
   arg6 = &temp6;
@@ -12764,12 +12763,11 @@ _wrap_memcached_fetch_rvalue(int argc, VALUE *argv, VALUE self) {
   VALUE result;
   VALUE vresult = Qnil;
 
-  {
-    char string[256];
-    size_t length = 0;
-    arg2 = string;
-    arg3 = &length;
-  }
+  char string[256];
+  size_t length = 0;
+  arg2 = string;
+  arg3 = &length;
+
   arg4 = &temp4;
   arg5 = &temp5;
   if ((argc < 1) || (argc > 1)) {


### PR DESCRIPTION
'rake test' on a fresh checkout of the memcached gem (1.5.0 c334c52cbd) crashes when run with ruby 1.9.3-p429. The test that triggers the crash is test/unit/memcached_test.rb - test_get_multi_binary_one_record_missing.

Environment:
Ubuntu 12.10 64-bit
ruby 1.9.3-p429 (also tested with the same result with p392)
gcc version 4.7.2 (Ubuntu/Linaro 4.7.2-2ubuntu1)

Full stack trace: https://gist.github.com/plerohellec/5657931/raw/c3dc62be8df1269c4db030c49d9838e4a4dfabcd/memcached_segfault

In short:
/home/philippe/src/plerohellec/memcached/lib/memcached/memcached.rb:499: [BUG] Segmentation fault
ruby 1.9.3p429 (2013-05-15 revision 40747) [x86_64-linux]

-- Control frame information -----------------------------------------------
c:0026 p:---- s:0112 b:0112 l:000111 d:000111 CFUNC :memcached_fetch_rvalue
c:0025 p:0085 s:0108 b:0108 l:000107 d:000107 METHOD /home/philippe/src/plerohellec/memcached/lib/memcached/memcached.rb:499
c:0024 p:0035 s:0096 b:0094 l:000093 d:000093 METHOD /home/philippe/src/plerohellec/memcached/test/unit/memcached_test.rb:388

It blows up in memcached_fetch_rvalue. I believe the crash is caused by arg3 in _wrap_memcached_fetch_rvalue that points to a local variable (length) that is out of scope at the time of the crash. memcached_fetch_rvalue on line 12782 of rlibmemcached_wrap.c fails and does not set arg3 to any value, so arg3 stays on the "length" deallocated stack address. arg3 ends up pointing to a very high value that is used to allocated a ruby string. The value is too high and that makes ruby crash.
