### PR TITLE
Fix Memcached::Rails increment and decrement to match ActiveSupport's memcache implementation.

### DIFF
--- a/lib/memcached/rails.rb
+++ b/lib/memcached/rails.rb
@@ -180,5 +180,19 @@ class Memcached
       end
       super
     end
+
+    def increment(name, amount = 1, options = nil)
+      response = super(name, amount)
+      response ? response.to_i : nil
+    rescue
+      nil
+    end
+
+    def decrement(name, amount = 1, options = nil)
+      response = super(name, amount)
+      response ? response.to_i : nil
+    rescue
+      nil
+    end
   end
 end

--- a/test/unit/rails_test.rb
+++ b/test/unit/rails_test.rb
@@ -250,6 +250,32 @@ class RailsTest < Test::Unit::TestCase
     assert_equal nil, @cache.read("x")
   end
 
+  def test_increment
+    rand_key = "rand-key-#{rand}"
+    assert_equal nil, @cache.increment(rand_key)
+
+    start = 10
+    @cache.write rand_key, start.to_s, { raw: true }
+
+    assert_equal start, @cache.read(rand_key, { raw: true }).to_i
+    assert_equal start+1, @cache.increment(rand_key)
+
+    assert_equal start+1+5, @cache.increment(rand_key, 5)
+  end
+
+  def test_decrement
+    rand_key = "rand-key-#{rand}"
+    assert_equal nil, @cache.decrement(rand_key)
+
+    start = 10
+    @cache.write rand_key, start.to_s, { raw: true }
+
+    assert_equal start, @cache.read(rand_key, { raw: true }).to_i
+    assert_equal start-1, @cache.decrement(rand_key)
+
+    assert_equal start-1-5, @cache.decrement(rand_key, 5)
+  end
+
   private
 
   def key


### PR DESCRIPTION
Nil is returned when key is not found or other error is encountered.  Otherwise a non-null return value is converted into an integer.
