### PR TITLE
Add support for Memcached::Rails write option :unless_exist

### DIFF
--- a/lib/memcached/rails.rb
+++ b/lib/memcached/rails.rb
@@ -97,7 +97,13 @@ class Memcached
     # Alternative to #set. Accepts a key, value, and an optional options hash supporting the
     # options :raw and :ttl.
     def write(key, value, options = {})
-      set(key, value, options[:ttl] || options[:expires_in] || @default_ttl, options[:raw])
+      value = value.to_s if options && options[:raw]
+      ttl = options[:ttl] || options[:expires_in] || @default_ttl
+      if options && options[:unless_exist]
+        add(key, value, ttl, options[:raw])
+      else
+        set(key, value, ttl, options[:raw])
+      end
     end
 
     def fetch(key, options={})

--- a/test/unit/rails_test.rb
+++ b/test/unit/rails_test.rb
@@ -196,6 +196,24 @@ class RailsTest < Test::Unit::TestCase
     @cache.write key, @value, :expires_in => 123
   end
 
+  def test_write_with_unless_exist
+    @cache.write key, @value, :unless_exist => true
+    result = @cache.get key
+    assert_equal @value, result
+
+    rand_value = "rand-value-#{rand}"
+    @cache.write key, rand_value, :unless_exist => true
+
+    result = @cache.get key
+    assert_equal @value, result
+  end
+
+  def test_write_with_fixnum_and_raw
+    @cache.write key, 1, :raw => true
+    result = @cache.read key, :raw => true
+    assert_equal "1", result
+  end
+
   def test_add_with_duration
     @cache.add key, @value, @duration
     result = @cache.get key


### PR DESCRIPTION
Fix Memcached::Rails write method to match ActiveSupport memcache write behavior:

1) Support :unless_exist option (don't write value if key already exists).
2) Convert values to string if :raw is true.  This allows values like Fixnum's to be passed into write.
