### PR TITLE
Fix Memcached::Rails read to allow nil options to be passed.

### DIFF
--- a/lib/memcached/rails.rb
+++ b/lib/memcached/rails.rb
@@ -53,8 +53,12 @@ class Memcached
 
     # Alternative to #get. Accepts a key and an optional options hash supporting the single option
     # :raw.
-    def read(key, options = {})
-      get(key, options[:raw])
+    def read(key, options = nil)
+      if options
+        get(key, options[:raw])
+      else
+        get(key)
+      end
     end
 
     # Returns whether the key exists, even if the value is nil.

--- a/test/unit/rails_test.rb
+++ b/test/unit/rails_test.rb
@@ -307,6 +307,11 @@ class RailsTest < Test::Unit::TestCase
     assert_equal start-1-5, @cache.decrement(rand_key, 5)
   end
 
+  def test_read_with_nil_options
+    @cache.write key, @value
+    assert_equal @value, @cache.read(key, nil)
+  end
+
   private
 
   def key


### PR DESCRIPTION
The Memcached::Rails read method now allows nil to be passed in without throwing an error.  Also, the default `options` value is now changed to nil instead of `{}` to match the behavior of ActiveSupport cache's read.
