### PR TITLE
Update README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -75,11 +75,11 @@ Note that the API is not the same as that of <b>Ruby-MemCache</b> or <b>memcache
   $cache.delete 'test'
   $cache.get 'test' #=> raises Memcached::NotFound
 
-== Rails
+== Rails 3.x
 
   # config/environment.rb
   require "memcached/rails"
-  config.cache_store = Memcached::Rails.new(:servers => ['127.0.0.1'])
+  config.cache_store = :mem_cache_store, Memcached::Rails.new(:servers => ['127.0.0.1'])
 
 == Pipelining
 


### PR DESCRIPTION
Update readme with right rails `cache_store` config.
Also add `3.x` because the config doesnt work on rails4, as the mem_cache_store adapter now only works with dalli. see https://github.com/rails/rails/blob/4-0-stable/activesupport/lib/active_support/cache/mem_cache_store.rb and https://github.com/rails/rails/blob/4-0-stable/activesupport/lib/active_support/cache/mem_cache_store.rb#L141 which breaks the memcached gem API.

(I am working on https://github.com/Shopify/rails_cache_adapters to make an adapter to memcached + rails4), after I finish it, I can update the instructions to use it on rails 4.
