### PR TITLE
Fix block in cas for Ruby 1.8.7

### DIFF
--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -440,7 +440,7 @@ Please note that when <tt>:no_block => true</tt>, update methods do not raise on
       unless hash.empty?
         hash = yield hash
         # Only CAS entries that were updated from the original hash
-        hash.delete_if {|k| !flags_and_cas.has_key?(k) }
+        hash.delete_if {|k, _| !flags_and_cas.has_key?(k) }
         hash = multi_cas(hash, ttl, flags_and_cas, decode, tries)
       end
       hash


### PR DESCRIPTION
Blocks in Ruby 1.8.7 check the argument count. This adds an ignored argument to a `delete_if` block in `cas`.

@arthurnn for review.
