### PR TITLE
Fix truncation of bytes/bytes_read/bytes_written stats

### DIFF
--- a/ext/libmemcached-0.32/libmemcached/memcached_stats.c
+++ b/ext/libmemcached-0.32/libmemcached/memcached_stats.c
@@ -87,15 +87,15 @@ static memcached_return set_data(memcached_stat_st *memc_stat, char *key, char *
   }
   else if (!strcmp("bytes_read", key))
   {
-    memc_stat->bytes_read= (uint32_t) strtoll(value, (char **)NULL, 10);
+    memc_stat->bytes_read= (uint64_t) strtoll(value, (char **)NULL, 10);
   }
   else if (!strcmp("bytes_written", key))
   {
-    memc_stat->bytes_written= (uint32_t) strtoll(value, (char **)NULL, 10);
+    memc_stat->bytes_written= (uint64_t) strtoll(value, (char **)NULL, 10);
   }
   else if (!strcmp("bytes", key))
   {
-    memc_stat->bytes= (uint32_t) strtoll(value, (char **)NULL, 10);
+    memc_stat->bytes= (uint64_t) strtoll(value, (char **)NULL, 10);
   }
   else if (!strcmp("curr_connections", key))
   {


### PR DESCRIPTION
These stats are stored in a `uint64_t` but we were truncating them to 32 bits.
