### PR TITLE
Fix warnings

### DIFF
--- a/lib/memcached/exceptions.rb
+++ b/lib/memcached/exceptions.rb
@@ -1,4 +1,3 @@
-
 class Memcached
 
 =begin rdoc
@@ -48,6 +47,11 @@ Subclasses correspond one-to-one with server response strings or libmemcached er
 =end
   class Error < RuntimeError
     attr_accessor :no_backtrace
+
+    def initialize(*args)
+      @no_backtrace = nil
+      super(*args)
+    end
 
     def set_backtrace(*args)
       @no_backtrace ? [] : super

--- a/lib/memcached/experimental.rb
+++ b/lib/memcached/experimental.rb
@@ -22,7 +22,7 @@ class Memcached
 
         hash = {}
         keys.each do
-          value, key, flags, ret = Lib.memcached_fetch_rvalue(@struct)
+          value, key, _flags, ret = Lib.memcached_fetch_rvalue(@struct)
           break if ret == Lib::MEMCACHED_END
           if ret != Lib::MEMCACHED_NOTFOUND
             check_return_code(ret, key)
@@ -33,7 +33,7 @@ class Memcached
         hash
       else
         # Single get_len
-        value, flags, ret = Lib.memcached_get_len_rvalue(@struct, keys, bytes)
+        value, _flags, ret = Lib.memcached_get_len_rvalue(@struct, keys, bytes)
         check_return_code(ret, keys)
         value
       end

--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -634,8 +634,8 @@ But it was #{server}.
   # FIXME Is this still necessary with cached_errno?
   def detect_failure
     time = Time.now
-    server = server_structs.detect do |server|
-      server.next_retry > time
+    server = server_structs.detect do |server_struct|
+      server_struct.next_retry > time
     end
     inspect_server(server) if server
   end
@@ -697,8 +697,8 @@ But it was #{server}.
       value, key, flags, ret = Lib.memcached_fetch_rvalue(@struct)
     end
     if decode
-      hash.each do |key, value_and_flags|
-        hash[key] = @codec.decode(key, *value_and_flags)
+      hash.each do |inner_key, value_and_flags|
+        hash[inner_key] = @codec.decode(inner_key, *value_and_flags)
       end
     end
     [hash, flags_and_cas]

--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -197,7 +197,7 @@ Please note that when <tt>:no_block => true</tt>, update methods do not raise on
           args = [@struct, server, options[:default_weight].to_i]
           Lib.memcached_server_add_unix_socket_with_weight(*args)
         # Network
-        elsif server.is_a?(String) and server =~ /^[\w\d\.-]+(:\d{1,5}){0,2}$/
+        elsif server.is_a?(String) and server =~ /^[\w\.-]+(:\d{1,5}){0,2}$/
           host, port, weight = server.split(":")
           args = [@struct, host, port.to_i, (weight || options[:default_weight]).to_i]
           if options[:use_udp]

--- a/test/unit/memcached_experimental_test.rb
+++ b/test/unit/memcached_experimental_test.rb
@@ -89,7 +89,7 @@ class MemcachedExperimentalTest < Test::Unit::TestCase
       value = "Test that we cannot get 0 bytes with a get_len call."
       @experimental_cache.set key, value, 0, false
       assert_raises(Memcached::Failure) do
-        result = @experimental_cache.get_len 0, key
+        @experimental_cache.get_len 0, key
       end
     end
   end
@@ -119,7 +119,7 @@ class MemcachedExperimentalTest < Test::Unit::TestCase
     server_get_len_capable do
       @experimental_binary_protocol_cache.set key, @value
       assert_raises(Memcached::ActionNotSupported) do
-        result = @experimental_binary_protocol_cache.get_len 2, key
+        @experimental_binary_protocol_cache.get_len 2, key
       end
     end
   end
@@ -173,7 +173,7 @@ class MemcachedExperimentalTest < Test::Unit::TestCase
       @experimental_binary_protocol_cache.set key_1, value_1, 0, false
       @experimental_binary_protocol_cache.set key_2, value_2, 0, false
       assert_raises(Memcached::ActionNotSupported) do
-        result = @experimental_binary_protocol_cache.get_len 2, keys
+        @experimental_binary_protocol_cache.get_len 2, keys
       end
     end
   end
@@ -191,9 +191,9 @@ class MemcachedExperimentalTest < Test::Unit::TestCase
 
   def test_get_len_failure
     server_get_len_capable do
-      value = "Test that we cannot use get_len without setting the :experimental_features config."
+      # Test that we cannot use get_len without setting the :experimental_features config.
       assert_raises(NoMethodError) do
-        result = @cache.get_len 10, key
+        @cache.get_len 10, key
       end
     end
   end

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -993,21 +993,21 @@ class MemcachedTest < Test::Unit::TestCase
     @cache.get key, @value
     assert false # Never reached
   rescue Memcached::ABadKeyWasProvidedOrCharactersOutOfRange => e
-    assert_match /#{key}/, e.message
+    assert_match(/#{key}/, e.message)
   end
 
   def test_server_error_message
     @cache.set key, "I'm big" * 1000000
     assert false # Never reached
   rescue Memcached::ServerError => e
-    assert_match /^"object too large for cache". Key/, e.message
+    assert_match(/^"object too large for cache". Key/, e.message)
   end
 
   def test_errno_message
     Rlibmemcached::MemcachedServerSt.any_instance.stubs("cached_errno").returns(1)
     @cache.send(:check_return_code, Rlibmemcached::MEMCACHED_ERRNO, key)
   rescue Memcached::SystemError => e
-    assert_match /^Errno 1: "Operation not permitted". Key/, e.message
+    assert_match(/^Errno 1: "Operation not permitted". Key/, e.message)
   end
 
   # Stats
@@ -1160,7 +1160,7 @@ class MemcachedTest < Test::Unit::TestCase
       cache.get(key2)
     rescue => e
       assert_equal Memcached::ServerIsMarkedDead, e.class
-      assert_match /localhost:43041/, e.message
+      assert_match(/localhost:43041/, e.message)
     end
 
     # Hit first server on retry
@@ -1235,7 +1235,7 @@ class MemcachedTest < Test::Unit::TestCase
       cache.get(key2)
     rescue => e
       assert_equal Memcached::ServerIsMarkedDead, e.class
-      assert_match /localhost:43041/, e.message
+      assert_match(/localhost:43041/, e.message)
     end
 
     assert_nothing_raised do
@@ -1249,7 +1249,7 @@ class MemcachedTest < Test::Unit::TestCase
       cache.get(key2)
     rescue => e
       assert_equal Memcached::ServerIsMarkedDead, e.class
-      assert_match /localhost:43041/, e.message
+      assert_match(/localhost:43041/, e.message)
     end
 
     assert_nothing_raised do
@@ -1280,7 +1280,7 @@ class MemcachedTest < Test::Unit::TestCase
       cache.get(key2)
     rescue => e
       assert_equal Memcached::ServerIsMarkedDead, e.class
-      assert_match /localhost:43041/, e.message
+      assert_match(/localhost:43041/, e.message)
     end
 
     sleep(2)
@@ -1290,7 +1290,7 @@ class MemcachedTest < Test::Unit::TestCase
       cache.get(key2)
     rescue => e
       assert_equal Memcached::ServerIsMarkedDead, e.class
-      assert_match /localhost:43041/, e.message
+      assert_match(/localhost:43041/, e.message)
     end
   ensure
     socket.close
@@ -1343,7 +1343,7 @@ class MemcachedTest < Test::Unit::TestCase
       cache.get(key2)
     rescue => e
       assert_equal Memcached::ServerIsMarkedDead, e.class
-      assert_match /localhost:43041/, e.message
+      assert_match(/localhost:43041/, e.message)
     end
 
     # Hit first server on retry

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -274,7 +274,7 @@ class MemcachedTest < Test::Unit::TestCase
   def test_get_missing
     @cache.delete key rescue nil
     assert_raise(Memcached::NotFound) do
-      result = @cache.get key
+      @cache.get key
     end
   end
 
@@ -292,21 +292,21 @@ class MemcachedTest < Test::Unit::TestCase
     cache = Memcached.new("localhost:43047:1", :timeout => 0.5, :exception_retry_limit => 0)
     assert 0.49 < (Benchmark.measure do
       assert_raise(Memcached::ATimeoutOccurred) do
-        result = cache.get key
+        cache.get key
       end
     end).real
 
     cache = Memcached.new("localhost:43047:1", :poll_timeout => 0.001, :rcv_timeout => 0.5, :exception_retry_limit => 0)
     assert 0.49 < (Benchmark.measure do
       assert_raise(Memcached::ATimeoutOccurred) do
-        result = cache.get key
+        cache.get key
       end
     end).real
 
     cache = Memcached.new("localhost:43047:1", :poll_timeout => 0.25, :rcv_timeout => 0.25, :exception_retry_limit => 0)
     assert 0.51 > (Benchmark.measure do
       assert_raise(Memcached::ATimeoutOccurred) do
-        result = cache.get key
+        cache.get key
       end
     end).real
   ensure
@@ -318,14 +318,14 @@ class MemcachedTest < Test::Unit::TestCase
     cache = Memcached.new("localhost:43048:1", :no_block => true, :timeout => 0.25, :exception_retry_limit => 0)
     assert 0.24 < (Benchmark.measure do
       assert_raise(Memcached::ATimeoutOccurred) do
-        result = cache.get key
+        cache.get key
       end
     end).real
 
     cache = Memcached.new("localhost:43048:1", :no_block => true, :poll_timeout => 0.25, :rcv_timeout => 0.001, :exception_retry_limit => 0)
     assert 0.24 < (Benchmark.measure do
       assert_raise(Memcached::ATimeoutOccurred) do
-        result = cache.get key
+        cache.get key
       end
     end).real
 
@@ -336,7 +336,7 @@ class MemcachedTest < Test::Unit::TestCase
     )
     assert 0.24 > (Benchmark.measure do
       assert_raise(Memcached::ATimeoutOccurred) do
-        result = cache.get key
+        cache.get key
       end
     end).real
 
@@ -946,7 +946,7 @@ class MemcachedTest < Test::Unit::TestCase
     end
 
     assert_raises(Memcached::ABadKeyWasProvidedOrCharactersOutOfRange) do
-      response = @cache.get([key])
+      @cache.get([key])
     end
   end
 
@@ -960,7 +960,7 @@ class MemcachedTest < Test::Unit::TestCase
     end
 
     assert_raises(Memcached::ABadKeyWasProvidedOrCharactersOutOfRange) do
-      response = @cache.get([key])
+      @cache.get([key])
     end
   end
 


### PR DESCRIPTION
Rake runs ruby with warnings enabled by default now (ruby/rake#97)
