### PR TITLE
Make namespace setter persist across connections

### DIFF
--- a/lib/memcached/client.rb
+++ b/lib/memcached/client.rb
@@ -112,11 +112,12 @@ module Memcached
     end
 
     def namespace
-      connection.get_prefix
+      @prefix
     end
 
     def namespace=(value)
       connection.set_prefix(value)
+      @prefix = value
     end
 
     def touch(key, ttl = @default_ttl)

--- a/test/unit/client_test.rb
+++ b/test/unit/client_test.rb
@@ -198,4 +198,26 @@ class ClientTest < BaseTest
     cache.reset
     refute_equal cache.connection, con
   end
+
+  # Namespace
+
+  def test_namespace
+    cache.namespace = nil
+    cache.set('ns:key', @value)
+
+    cache.namespace = 'ns:'
+
+    assert_equal 'ns:', cache.namespace
+    assert_equal @value, cache.get('key')
+  end
+
+  def test_namespace_after_reset
+    cache.namespace = 'ns:'
+    cache.set('key', @value)
+
+    cache.reset
+
+    assert_equal 'ns:', cache.namespace
+    assert_equal @value, cache.get('key')
+  end
 end


### PR DESCRIPTION
Memcached::Client#namespace= only sets the prefix on the connection, but didn't update the `@prefix` instance variable on Memcached::Client so the prefix would be lost when the connection is reset.

Setting the `@prefix` instance variable avoids that problem.  I also thought it makes more sense to return that value for the Memcached::Client#namespace getter.