### PR TITLE
extconf: do not explicitly set timestamps

### DIFF
--- a/ext/memcached/extconf.rb
+++ b/ext/memcached/extconf.rb
@@ -39,8 +39,6 @@ def compile_libmemcached
     Dir.mkdir("build") if !Dir.exists?("build")
     build_folder = File.join(LIBMEMCACHED_DIR, "build")
 
-    ts_now=Time.now.strftime("%Y%m%d%H%M.%S")
-    run("find . | xargs touch -t #{ts_now}", "Touching all files so autoconf doesn't run.")
     run("env CFLAGS='-fPIC #{LIBM_CFLAGS}' LDFLAGS='-fPIC #{LIBM_LDFLAGS}' ./configure --prefix=#{build_folder} --libdir=#{build_folder}/lib --with-pic --without-memcached --disable-shared --disable-util\
 s --disable-dependency-tracking #{$CC} #{$EXTRA_CONF} 2>&1", "Configuring libmemcached.")
     run("#{GMAKE_CMD} clean 2>&1")


### PR DESCRIPTION
The current approach to setting timestamps can cause confusing errors building the vendored memcached in situations where the clock has drifted a bit from real time. The failed sanity check produces the error:

```
checking whether build environment is sane... configure: error: newly created file is older than distributed files!
Check your system clock
```

This kind of clock drift is very common when using [Docker for Mac](https://github.com/docker/for-mac/issues/2076) or [Windows](https://github.com/docker/for-win/issues/72). Ruby's Time.now appears to use a different clock from the one used by the timestamps for the file created as a part of the sanity check. As a result, a clock drift of as little as six seconds can cause the timestamps set on the source tree to be newer than the file created during the sanity check.

The bug that this was meant to fix doesn't seem to be an issue anymore; I'm not seeing `./configure` within the vendored memcached attempt to run autoconf. I think the timestamp code can safely be removed.