### PR TITLE
Fix build of libmemcached when there is an older vendor directory

### DIFF
--- a/ext/memcached/extconf.rb
+++ b/ext/memcached/extconf.rb
@@ -6,7 +6,7 @@ unless find_header('sasl/sasl.h')
 end
 
 HERE = File.expand_path(File.dirname(__FILE__))
-LIBMEMCACHED_DIR = Dir.glob(File.join(HERE, '..', '..', 'vendor',"libmemcached-*")).first
+LIBMEMCACHED_DIR = Dir.glob(File.join(HERE, '..', '..', 'vendor','libmemcached-1.0.18')).first
 
 SOLARIS_32 = RbConfig::CONFIG['target'] == "i386-pc-solaris2.10"
 BSD = RbConfig::CONFIG['host_os'].downcase =~ /bsd/


### PR DESCRIPTION
~~Based on https://github.com/arthurnn/memcached/pull/186 to fix CI, see https://github.com/dylanahsmith/memcached/compare/github-actions...fix-build-with-ignored-vendor-dir for this PRs changes~~

## Problem

On the 1-0-stable branch, libmemcached is built in a vendor/libmemcached-0.32 directory, where intermediate files are ignored by .gitignore.  So when I switch to the master branch, `bundle exec rake compile` will try to build libmemcached in the `vendor/libmemcached-0.32` directory (without the source files) and fail as follows

```
Configuring libmemcached.
env CFLAGS='-fPIC -O3 -ggdb3 -Wall -Wextra -Wdeprecated-declarations -Wdivision-by-zero -Wimplicit-function-declaration -Wimplicit-int -Wpointer-arith -Wshorten-64-to-32 -Wwrite-strings -Wmissing-noreturn -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wunused-variable -Wextra-tokens  -pipe   -pipe -Os' LDFLAGS='-fPIC -L. -fstack-protector-strong -L/usr/local/lib -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/readline/lib -L/usr/local/opt/libyaml/lib -L/usr/local/opt/gdbm/lib -L. -fstack-protector-strong -L/usr/local/lib -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/readline/lib -L/usr/local/opt/libyaml/lib -L/usr/local/opt/gdbm/lib -L/opt/rubies/2.7.2/lib' ./configure --prefix=/Users/dylants/src/memcached-ruby/ext/memcached/../../vendor/libmemcached-0.32/build --libdir=/Users/dylants/src/memcached-ruby/ext/memcached/../../vendor/libmemcached-0.32/build/lib --with-pic --without-memcached --disable-shared --disable-utils --disable-dependency-tracking CC="clang"  2>&1
env: ./configure: No such file or directory
Traceback (most recent call last):
	4: from ../../../../ext/memcached/extconf.rb:63:in `<main>'
	3: from ../../../../ext/memcached/extconf.rb:38:in `compile_libmemcached'
	2: from ../../../../ext/memcached/extconf.rb:38:in `chdir'
	1: from ../../../../ext/memcached/extconf.rb:44:in `block in compile_libmemcached'
../../../../ext/memcached/extconf.rb:60:in `run': 'env CFLAGS='-fPIC -O3 -ggdb3 -Wall -Wextra -Wdeprecated-declarations -Wdivision-by-zero -Wimplicit-function-declaration -Wimplicit-int -Wpointer-arith -Wshorten-64-to-32 -Wwrite-strings -Wmissing-noreturn -Wno-constant-logical-operand -Wno-long-long -Wno-missing-field-initializers -Wno-overlength-strings -Wno-parentheses-equality -Wno-self-assign -Wno-tautological-compare -Wno-unused-parameter -Wno-unused-value -Wunused-variable -Wextra-tokens  -pipe   -pipe -Os' LDFLAGS='-fPIC -L. -fstack-protector-strong -L/usr/local/lib -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/readline/lib -L/usr/local/opt/libyaml/lib -L/usr/local/opt/gdbm/lib -L. -fstack-protector-strong -L/usr/local/lib -L/usr/local/opt/openssl@1.1/lib -L/usr/local/opt/readline/lib -L/usr/local/opt/libyaml/lib -L/usr/local/opt/gdbm/lib -L/opt/rubies/2.7.2/lib' ./configure --prefix=/Users/dylants/src/memcached-ruby/ext/memcached/../../vendor/libmemcached-0.32/build --libdir=/Users/dylants/src/memcached-ruby/ext/memcached/../../vendor/libmemcached-0.32/build/lib --with-pic --without-memcached --disable-shared --disable-utils --disable-dependency-tracking CC="clang"  2>&1' failed (RuntimeError)
```

where you notice it trying to build in vendor/libmemcached-0.32 instead of the vendor/libmemcached-1.0.18 that is on master.

## Solution

Replace the glob suffix in ext/memcached/extconf.rb with the actual version meant to be built for this version of the code.