### PR TITLE
Fix ConcurrencyTest that needs to clone the client for thread-safety

### DIFF
--- a/test/unit/concurrency_test.rb
+++ b/test/unit/concurrency_test.rb
@@ -4,10 +4,11 @@ class ConcurrencyTest < BaseTest
   def test_multiple_threads_set_get
     Array.new(12) do |n|
       Thread.new do
-        cache.set("foo#{n}", "v#{n}")
-        assert_equal "v#{n}", cache.get("foo#{n}")
-        cache.set("foz#{n}", "v2#{n}")
-        assert_equal "v2#{n}", cache.get("foz#{n}")
+        thread_cache = cache.clone
+        thread_cache.set("foo#{n}", "v#{n}")
+        assert_equal "v#{n}", thread_cache.get("foo#{n}")
+        thread_cache.set("foz#{n}", "v2#{n}")
+        assert_equal "v2#{n}", thread_cache.get("foz#{n}")
       end
     end.each(&:join)
   end
@@ -17,10 +18,11 @@ class ConcurrencyTest < BaseTest
 
     Array.new(12) do |n|
       Thread.new do
+        thread_cache = cache.clone
         100.times do |i|
-          cache.set("foo#{n}#{i}", "v#{n}")
+          thread_cache.set("foo#{n}#{i}", "v#{n}")
         end
-        assert_equal "v#{n}", cache.get("foo#{n}2")
+        assert_equal "v#{n}", thread_cache.get("foo#{n}2")
       end
     end.each(&:join)
   end
@@ -28,10 +30,11 @@ class ConcurrencyTest < BaseTest
   def test_threads_with_binary
     Array.new(12) do |n|
       Thread.new do
+        thread_cache = binary_protocol_cache.clone
         100.times do |i|
-          binary_protocol_cache.set("foo#{n}#{i}", "v#{n}")
+          thread_cache.set("foo#{n}#{i}", "v#{n}")
         end
-        assert_equal "v#{n}", binary_protocol_cache.get("foo#{n}2")
+        assert_equal "v#{n}", thread_cache.get("foo#{n}2")
       end
     end.each(&:join)
   end
@@ -40,11 +43,12 @@ class ConcurrencyTest < BaseTest
   def test_threads_with_multi_get
     Array.new(12) do |n|
       Thread.new do
+        thread_cache = binary_protocol_cache.clone
         keys = Array.new(100) do |i|
-          binary_protocol_cache.set("foo#{n}#{i}", "v#{n}")
+          thread_cache.set("foo#{n}#{i}", "v#{n}")
           "foo#{n}#{i}"
         end
-        assert_equal Array.new(100) { "v#{n}" }, binary_protocol_cache.get_multi(keys).values
+        assert_equal Array.new(100) { "v#{n}" }, thread_cache.get_multi(keys).values
       end
     end.each(&:join)
   end


### PR DESCRIPTION
~~Based on https://github.com/arthurnn/memcached/pull/186 to fix CI, see https://github.com/dylanahsmith/memcached/compare/github-actions...fix-concurrency-test for this PRs changes~~

## Problem

I've noticed the following flaky test failure

```
  1) Failure:
ConcurrencyTest#test_threads_with_multi_get [/home/runner/work/memcached/memcached/test/unit/concurrency_test.rb:47]:
--- expected
+++ actual
@@ -1 +1 @@
-["v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11"]
+["v11", "v1", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11", "v11"]
```

which I was able to reproduce quite reliably locally by wrapping the test in an `100.times do` block.

Looking at the concurrency tests, I noticed that they are using the same client instance across threads, but the README's [Threading section](https://github.com/arthurnn/memcached/blob/cd5251271b5e078d64016d58dbc7d6eed1323da9/README.md#threading) says

> memcached is threadsafe, but each thread requires its own Memcached instance. Create a global Memcached, and then call Memcached#clone each time you spawn a thread.

so this is what should be being tested for thread-safety.

## Solution

I changed all the ConcurrencyTest methods to use the `clone` method as recommended in the README and it fixed the flaky test.