### PR TITLE
Fix gem install portability by avoiding a shell feature dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,4 @@ jobs:
         bundler-cache: true
     - run: bundle exec ruby test/setup.rb
     - run: bundle exec rake
+    - run: bundle exec rake install

--- a/memcached.gemspec
+++ b/memcached.gemspec
@@ -10,9 +10,9 @@ Gem::Specification.new do |s|
   s.summary = "An interface to the libmemcached C client."
   s.homepage = "http://evan.github.com/evan/memcached/"
 
-  s.files         = `git ls-files -- {lib,ext,vendor}/*`.split("\n") + %w(LICENSE README.md CHANGELOG)
-  s.test_files    = `git ls-files -- {test}/*`.split("\n")
-  s.require_paths = ["lib", "ext"]
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").grep(%r{^(lib|ext|vendor)/}) + %w(LICENSE README.md CHANGELOG)
+  end
   s.extensions = ["ext/memcached/extconf.rb"]
 
   s.licenses = ["Academic Free License 3.0 (AFL-3.0)"]


### PR DESCRIPTION
## Problem

@casperisfine I tried adding `bundle exec rake install` to CI as you suggested in https://github.com/arthurnn/memcached/pull/186#discussion_r608105670 and it failed.  I was able to reproduce the error in on ubuntu and found the source of the problem was the `{lib,ext,vendor}` shell glob expansion, which didn't work in the shell spawned by ruby.

E.g. in macOS I get

```
irb(main):001:0> `echo {lib,ext,vendor}`
=> "lib ext vendor\n"
```

but on Ubuntu I get

```
irb(main):001:0> `echo {lib,ext,vendor}`
=> "{lib,ext,vendor}\n"
```

## Solution

The gemspec file generated by `bundle gem` avoids this problem by doing file filtering using ruby, so it doesn't depend on what shell features are available.