### PR TITLE
tests: Fix concurrency test flakiness from unintentional key overlap

### DIFF
--- a/test/unit/concurrency_test.rb
+++ b/test/unit/concurrency_test.rb
@@ -20,9 +20,9 @@ class ConcurrencyTest < BaseTest
       Thread.new do
         thread_cache = cache.clone
         100.times do |i|
-          thread_cache.set("foo#{n}#{i}", "v#{n}")
+          thread_cache.set("foo#{n}-#{i}", "v#{n}")
         end
-        assert_equal "v#{n}", thread_cache.get("foo#{n}2")
+        assert_equal "v#{n}", thread_cache.get("foo#{n}-2")
       end
     end.each(&:join)
   end
@@ -32,9 +32,9 @@ class ConcurrencyTest < BaseTest
       Thread.new do
         thread_cache = binary_protocol_cache.clone
         100.times do |i|
-          thread_cache.set("foo#{n}#{i}", "v#{n}")
+          thread_cache.set("foo#{n}-#{i}", "v#{n}")
         end
-        assert_equal "v#{n}", thread_cache.get("foo#{n}2")
+        assert_equal "v#{n}", thread_cache.get("foo#{n}-2")
       end
     end.each(&:join)
   end
@@ -45,8 +45,8 @@ class ConcurrencyTest < BaseTest
       Thread.new do
         thread_cache = binary_protocol_cache.clone
         keys = Array.new(100) do |i|
-          thread_cache.set("foo#{n}#{i}", "v#{n}")
-          "foo#{n}#{i}"
+          thread_cache.set("foo#{n}-#{i}", "v#{n}")
+          "foo#{n}-#{i}"
         end
         assert_equal Array.new(100) { "v#{n}" }, thread_cache.get_multi(keys).values
       end


### PR DESCRIPTION
@casperisfine for review

## Problem

I noticed another flaky concurrency test [failure on CI](https://github.com/arthurnn/memcached/runs/2282769707):

```
  1) Failure:
ConcurrencyTest#test_threads_with_multi_get [/home/runner/work/memcached/memcached/test/unit/concurrency_test.rb:51]:
--- expected
+++ actual
@@ -1 +1 @@
-["v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1"]
+["v11", "v11", "v11", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v11", "v11", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v11", "v11", "v11", "v11", "v11", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1", "v1"]
```

which seems to be from the overlap of keys between threads that are supposed to have their own keys, since there is no separation between the thread number and key number on the set line (e.g. `thread_cache.set("foo#{n}#{i}", "v#{n}")`).  So thread 1, key 11 uses the key `foo111`, which is the same key as for thread 11, key 1.

## Solution

Add a separator between the thread number and key number.