### PR TITLE
Add CAS support

### DIFF
--- a/TODO.org
+++ b/TODO.org
@@ -9,5 +9,4 @@
 ** TODO add AS::Cache wrappper instead of Rails class
 ** TODO Add resiliency around the client
 ** TODO Implement connection pool
-** TODO CAS
 ** TODO add a better pipeline API

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,7 +40,7 @@ class BaseTest < Minitest::Test
 
   def cache
     return @cache if @cache
-    @cache = Memcached::Client.new(@servers, hash: :default, distribution: :modula, prefix_key: @prefix_key)
+    @cache = Memcached::Client.new(@servers, hash: :default, distribution: :modula, prefix_key: @prefix_key, support_cas: true)
   end
 
   def binary_protocol_cache

--- a/test/unit/client_cas_test.rb
+++ b/test/unit/client_cas_test.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+
+class ClientCASTest < BaseTest
+
+  def test_simple_cas
+    cache.set(key, "foo")
+    assert_equal "foo", cache.get(key)
+    result = cache.cas([key]) do
+      { key => @value }
+    end
+    assert_equal true, result
+    assert_equal @value, cache.get(key)
+  end
+
+  def test_cas_conflict
+    cache.set(key, "foo")
+    assert_equal "foo", cache.get(key)
+    result = cache.cas([key]) do
+      cache.set(key, "bar")
+      { key => @value }
+    end
+    assert_equal false, result
+    assert_equal "bar", cache.get(key)
+  end
+
+  def test_cas_miss
+    result = cache.cas([key]) do
+      flunk "CAS block shouldn't be called on miss"
+    end
+    assert_equal false, result
+    assert_nil cache.get(key)
+  end
+
+  def test_cas_changed_keys
+    cache.set(key, "foo")
+    result = cache.cas([key]) do
+      { "#{key}:new" => "bar" }
+    end
+    assert_equal false, result
+    assert_nil cache.get("#{key}:new")
+  end
+
+  def test_cas_partial_miss
+    cache.set(key, "foo")
+    result = cache.cas([key, "missing:#{key}"]) do |values|
+      assert_equal({ key => "foo" }, values)
+      { key => "bar" }
+    end
+    assert_equal true, result
+    assert_equal "bar", cache.get(key)
+  end
+end


### PR DESCRIPTION
It is fairly basic for now, so I'm looking for feedback before all.

Since `libmemcached` requires to use the `mget` API to get the CAS token back, I implemented it as a "cas_multi".

I'm not too sure about the return value, I tried to return false when any of the values returned by the block wouldn't not be stored.

@dylanahsmith thougths?