### PR TITLE
Remove broken ClientError retry logic that effectively did nothing

### DIFF
--- a/lib/memcached/memcached.rb
+++ b/lib/memcached/memcached.rb
@@ -326,7 +326,6 @@ But it was #{server}.
       )
     rescue => e
       tries ||= 0
-      retry if e.instance_of?(ClientError) && !tries
       raise unless tries < options[:exception_retry_limit] && should_retry(e)
       tries += 1
       retry

--- a/test/unit/memcached_test.rb
+++ b/test/unit/memcached_test.rb
@@ -558,16 +558,6 @@ class MemcachedTest < Test::Unit::TestCase
     end
   end
 
-  def disabled_test_set_retry_on_client_error
-    # FIXME Test passes, but Mocha doesn't restore the original method properly
-    Rlibmemcached.stubs(:memcached_set).raises(Memcached::ClientError)
-    Rlibmemcached.stubs(:memcached_set).returns(0)
-
-    assert_nothing_raised do
-      @cache.set(key, @value)
-    end
-  end
-
   # Delete
 
   def test_delete


### PR DESCRIPTION
Closes #155. cc @erks

As pointed out in #155, the `!tries` condition was never true, so the `if` statement that uses it was just dead code. As I replied in that PR

> From commit a5042221023f53f270f6a2e4b01319b4ece2e3c9 the previous version of this retry code had a `# FIXME Memcached 1.2.8 occasionally rejects valid sets` comment, so it looks like it was just working around a server bug.

So instead of "fixing" that `if` statement, this PR proposes to instead just remove it along with the associated disabled test (i.e. the method doesn't start with `test_`).