### PR TITLE
Use rb_external_str_new_with_enc to reduce coupling to RString struct

### DIFF
--- a/ext/rlibmemcached/rlibmemcached.i
+++ b/ext/rlibmemcached/rlibmemcached.i
@@ -156,27 +156,13 @@ VALUE rb_str_new_by_ref(char *ptr, long len);
 VALUE rb_str_new_by_ref(char *ptr, long len)
 {
 #ifdef OBJSETUP
-    NEWOBJ(str, struct RString);
-    OBJSETUP(str, rb_cString, T_STRING);
-    #ifdef RSTRING_NOEMBED
-        /* Ruby 1.9 */
-        str->as.heap.ptr = ptr;
-        str->as.heap.len = len;
-        str->as.heap.aux.capa = len + 1;
-        // Set STR_NOEMBED
-        FL_SET(str, FL_USER1);
-    #else
-        /* Ruby 1.8 */
-        str->ptr = ptr;
-        str->len = len;
-        str->aux.capa = 0;
-    #endif
+    VALUE str = rb_external_str_new_with_enc(ptr, len, rb_ascii8bit_encoding());
 #else
     /* Rubinius, JRuby */
     VALUE str = rb_str_new(ptr, len);
     free(ptr);
 #endif
-    return (VALUE)str;
+    return str;
 }
 %}
 

--- a/ext/rlibmemcached/rlibmemcached_wrap.c
+++ b/ext/rlibmemcached/rlibmemcached_wrap.c
@@ -2253,27 +2253,13 @@ SWIG_From_unsigned_SS_int  (unsigned int value)
 VALUE rb_str_new_by_ref(char *ptr, long len)
 {
 #ifdef OBJSETUP
-    NEWOBJ(str, struct RString);
-    OBJSETUP(str, rb_cString, T_STRING);
-    #ifdef RSTRING_NOEMBED
-        /* Ruby 1.9 */
-        str->as.heap.ptr = ptr;
-        str->as.heap.len = len;
-        str->as.heap.aux.capa = len + 1;
-        // Set STR_NOEMBED
-        FL_SET(str, FL_USER1);
-    #else
-        /* Ruby 1.8 */
-        str->ptr = ptr;
-        str->len = len;
-        str->aux.capa = 0;
-    #endif
+    VALUE str = rb_external_str_new_with_enc(ptr, len, rb_ascii8bit_encoding());
 #else
     /* Rubinius, JRuby */
     VALUE str = rb_str_new(ptr, len);
     free(ptr);
 #endif
-    return (VALUE)str;
+    return str;
 }
 
 


### PR DESCRIPTION
@casperisfine for review

## Problem

When running the test suite using ruby 3, I was getting a couple of these warnings

```
RSTRING_PTR is returning NULL!! SIGSEGV is highly expected to follow immediately. If you could reproduce, attach your debugger here, and look at the passed string.
```

I found one instance coming from test/unit/memcached_test.rb test_get_multi_empty_string which sets and gets an empty raw string value from the cache.  It looks like memcached is using a `NULL` string pointer when the length is `0`, which makes sense.  Unfortunately, the ruby string reference is setup by setting the RString struct values directly, leading to this problem, as well as potentially leading to more problems in the future.

## Solution

Use `rb_external_str_new_with_enc` to create a ruby string from an external C string, which has a condition for the length being 0 and avoids this internal ruby coupling.