### PR TITLE
Patch libmemcached to handle EINTR in poll(2)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'test-unit'
+gem "stackprof"
 
 group :benchmark do
   gem "remix-stash", '~> 1.1.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,6 +24,7 @@ GEM
     rake-compiler (1.1.1)
       rake
     remix-stash (1.1.3)
+    stackprof (0.2.17)
     test-unit (3.4.0)
       power_assert
     tzinfo (2.0.4)
@@ -42,6 +43,7 @@ DEPENDENCIES
   rake
   rake-compiler
   remix-stash (~> 1.1.3)
+  stackprof
   test-unit
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -15,6 +15,10 @@ Rake::TestTask.new do |t|
 end
 task :default => [:compile, :test]
 
+Rake::Task[:clean].enhance do
+  FileUtils.rm_rf(File.read(".gitignore").lines.flat_map { |l| Dir["**/#{l.chomp}"] })
+end
+
 task :swig do
   run("swig -DLIBMEMCACHED_WITH_SASL_SUPPORT -Ivendor/libmemcached-0.32 -ruby -autorename -o ext/rlibmemcached/rlibmemcached_wrap.c ext/rlibmemcached/rlibmemcached.i", "Running SWIG")
 end


### PR DESCRIPTION
There was two places where `libmemcached` uses `poll` but doesn't handle `EINTR`.

One was on the `connect` path, the other in the non-blocking IO read path.

I applied a similar path to both, basically unlimited retry as long as poll fail with `errno == EINTR`.

I wrote two tests relying on StackProf, to make sure they are close to reality.