### PR TITLE
Avoid using out of scope stack allocation

### DIFF
--- a/ext/rlibmemcached/extconf.rb
+++ b/ext/rlibmemcached/extconf.rb
@@ -48,8 +48,8 @@ def check_libmemcached
     Dir.mkdir("build")
     build_folder = File.join(LIBMEMCACHED_DIR, "build")
     run("env CFLAGS='-fPIC #{LIBM_CFLAGS}' LDFLAGS='-fPIC #{LIBM_LDFLAGS}' ./configure --prefix=#{build_folder} --libdir=#{build_folder}/lib --without-memcached --disable-shared --disable-utils --disable-dependency-tracking #{$CC} #{$EXTRA_CONF} 2>&1", "Configuring libmemcached.")
-    run("#{GMAKE_CMD} CXXFLAGS='#{$CXXFLAGS}' 2>&1")
-    run("#{GMAKE_CMD} install 2>&1")
+    run("cd libmemcached && #{GMAKE_CMD} CXXFLAGS='#{$CXXFLAGS}' 2>&1")
+    run("cd libmemcached && #{GMAKE_CMD} install 2>&1")
 
 
     pcfile = File.join(LIBMEMCACHED_DIR, "build", "lib", "pkgconfig", "libmemcached.pc")

--- a/ext/rlibmemcached/rlibmemcached.i
+++ b/ext/rlibmemcached/rlibmemcached.i
@@ -109,11 +109,11 @@
  $result = UINT2NUM($1);
 };
 
-%typemap(in, numinputs=0) (const char **key, size_t *key_length) {
-  const char *key_ptr;
-  size_t key_length_ptr;
-  $1 = &key_ptr;
-  $2 = &key_length_ptr;
+%typemap(in, numinputs=0, noblock=1) (const char **key, size_t *key_length) {
+  char *key_ptr$argnum;
+  size_t key_length_ptr$argnum;
+  $1 = &key_ptr$argnum;
+  $2 = &key_length_ptr$argnum;
 }
 
 // String for memcached_fetch

--- a/ext/rlibmemcached/rlibmemcached_wrap.c
+++ b/ext/rlibmemcached/rlibmemcached_wrap.c
@@ -12866,12 +12866,10 @@ _wrap_memcached_fetch_rvalue(int argc, VALUE *argv, VALUE self) {
   VALUE result;
   VALUE vresult = Qnil;
   
-  {
-    const char *key_ptr;
-    size_t key_length_ptr;
-    arg2 = &key_ptr;
-    arg3 = &key_length_ptr;
-  }
+  char *key_ptr2;
+  size_t key_length_ptr2;
+  arg2 = &key_ptr2;
+  arg3 = &key_length_ptr2;
   arg4 = &temp4;
   arg5 = &temp5;
   if ((argc < 1) || (argc > 1)) {


### PR DESCRIPTION
Previously the swig-generated code here used an invalid pattern:

``` c
  {
    const char *key_ptr;
    size_t key_length_ptr;
    arg2 = &key_ptr;
    arg3 = &key_length_ptr;
  }
  // read and write through the pointers in arg2 and arg3
```

As `key_ptr` and `key_length_ptr` were declared in that scope, once we leave the scope their memory is no longer valid. Address Sanitizer detects and reports this, but fortunately, as far as I can tell, under more "regular" compiler settings there is no difference (I diff'd the assembly output and it was identical) and this happens to work fine as the memory is reserved but not used for other purposes.

The second commit here adjusts extconf to only build the `libmemcached/` subdirectory of the vendored libmemcached, skipping tests, clients and others. This made building with ASAN work (otherwise it failed linking some of the other subprojects) and should be a bit faster and more resilient anyways.